### PR TITLE
small fixes for Fedora distro

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ ifeq ($(NCURSES_LIBS),)
     NCURSES_LIBS = -lncursesw
 endif
 
-CFLAGS = -Wall -Wextra -g -D_FORTIFY_SOURCE=2 $(NCURSES_CFLAGS)
+CFLAGS = -Wall -Wextra -O2 -g -D_FORTIFY_SOURCE=2 $(NCURSES_CFLAGS)
 LDFLAGS = $(NCURSES_LIBS)
 OBJ = kernel-install.o
 TARGET = kernel-installer

--- a/distro/fedora.h
+++ b/distro/fedora.h
@@ -5,6 +5,18 @@
 
 #include "common.h"
 
+static void replace_char(const char *src, char *dst, char c, char r, size_t length) {
+    for (size_t i = 0; i < length - 1; i++) {
+        dst[i] = src[i];
+        if (src[i] == c)
+            dst[i] = r;
+        if (src[i] == '\0')
+            return;
+    }
+
+    dst[length - 1] = '\0';
+}
+
 void fedora_install_dependencies() {
     run("sudo dnf install -y "
         "gcc make ncurses-devel bison flex openssl-devel elfutils-libelf-devel "
@@ -16,31 +28,36 @@ void fedora_build_and_install(const char* home, const char* version, const char*
     char source_dir[512];
     
     snprintf(source_dir, sizeof(source_dir), "%s/kernel_build/linux-%s", home, version);
-    
+
+    // Cambia algunas configuraciones que tiene el kernel de Fedora que no es
+    // posible replicar directamente, relacionadas a Secure Boot.
+    snprintf(cmd, sizeof(cmd),
+             "cd %s && "
+             "sed -i 's/CONFIG_SYSTEM_TRUSTED_KEYS=.*/CONFIG_SYSTEM_TRUSTED_KEYS=\"\"/' .config && "
+             "sed -i 's/CONFIG_EFI_SBAT=.*/CONFIG_EFI_SBAT=\"\"/' .config && "
+             "sed -i 's/CONFIG_EFI_SBAT_FILE=.*/CONFIG_EFI_SBAT_FILE=\"\"/' .config",
+             source_dir);
+    run(cmd);
+
     // Compilar generando RPMs
     snprintf(cmd, sizeof(cmd),
-             "cd %s && LC_ALL=C stdbuf -oL -eL make -j$(nproc) rpm-pkg",
+             "cd %s && LC_ALL=C stdbuf -oL -eL make -j$(nproc) binrpm-pkg",
              source_dir);
     run_build_with_progress(cmd, source_dir);
     
     // Instalar los RPMs generados
-    // Los RPMs suelen generarse en ~/rpmbuild/RPMS/x86_64/ o similar, pero make rpm-pkg
-    // puede dejarlos en el directorio local o en la estructura de rpmbuild por defecto.
-    // El kernel suele usar su propia estructura interna si no se define otra cosa,
-    // pero rpm-pkg usa la infraestructura de rpmbuild del usuario.
-    // Verificaremos la ubicación estándar de rpmbuild en el home del usuario.
+    // A partir de la version 6.6 del kernel, todos los paquetes generados por make *rpm-pkg
+    // se localizan dentro de la raiz del codigo fuente del kernel, especificamente
+    // en el directorio ./rpmbuild/RPMS/$(uname -m).
     
+    // La version en el rpm es cambiaba, reemplazando los '-' por '_' en la parte del tag.
+    char tag_rpm[64];
+    replace_char(tag, tag_rpm, '-', '_', 64);
+
     snprintf(cmd, sizeof(cmd),
              "cd %s/rpmbuild/RPMS/$(uname -m) && "
              "sudo dnf install -y kernel-%s*%s*.rpm kernel-headers-%s*%s*.rpm kernel-devel-%s*%s*.rpm",
-             home, version, tag, version, tag, version, tag);
-             
-    // Nota: Si make rpm-pkg no usa ~/rpmbuild, podría necesitar ajuste.
-    // Por defecto make rpm-pkg construye en el árbol del kernel pero usa rpmbuild.
-    // Una alternativa más segura si no sabemos dónde caen es buscar en el home.
-    
-    // Vamos a intentar instalar lo que encontremos en el directorio de build del kernel si rpmbuild no está.
-    // Pero lo estándar es ~/rpmbuild. Asumiremos eso por ahora.
+             source_dir, version, tag_rpm, version, tag_rpm, version, tag_rpm);
     
     run(cmd);
 }


### PR DESCRIPTION
Cambios para la compilación de Fedora

 - Se modifican algunas configuraciones conflictivas de origen del kernel de Fedora.
 - Se actualizan los comandos para compilar el enpaquetado del kernel.
 - Se ajusta comando de instalación de paquetes.
 - Se agrega opción `-O2` en Makefile por advertencia de compilación con flag `-D_FORTIFY_SOURCE=2`